### PR TITLE
:fire: add chromosome scaffold filtering

### DIFF
--- a/pycisTopic/pseudobulk_peak_calling.py
+++ b/pycisTopic/pseudobulk_peak_calling.py
@@ -23,6 +23,7 @@ def export_pseudobulk(
     bed_path: str,
     bigwig_path: str,
     path_to_fragments: Optional[Dict[str, str]] = None,
+    chrom_filter: Optional[str] = None,
     sample_id_col: Optional[str] = "sample_id",
     n_cpu: Optional[int] = 1,
     normalize_bigwig: Optional[bool] = True,
@@ -55,6 +56,9 @@ def export_pseudobulk(
             A dictionary of character strings, with sample name as names indicating the path to the fragments file/s from which pseudobulk profiles have to
             be created. If a :class:`CistopicObject` is provided as input it will be ignored, but if a cell metadata :class:`pd.DataFrame` is provided it
             is necessary to provide it. The keys of the dictionary need to match with the sample_id tag added to the index names of the input data frame.
+    chrom_filter: str, optional
+            A regular expression to filter out scaffolds like GL/KI genes from the fragments list.
+            Example: `"GL|KI"`
     sample_id_col: str, optional
             Name of the column containing the sample name per barcode in the input :class:`CistopicObject.cell_data` or class:`pd.DataFrame`. Default: 'sample_id'.
     n_cpu: int, optional
@@ -129,6 +133,12 @@ def export_pseudobulk(
                         prepare_tag_cells(cell_data.index.tolist(), split_pattern)
                     )
                 ]
+            if chrom_filter is not None:
+                fragment_drop = fragments_df.Chromosome.str.contains(chrom_filter)
+                n_fragments_dropped = fragment_drop.sum()
+                log.info("Filtering out " + str(n_fragments_dropped) + " fragments.")
+                fragments_df.drop(fragments_df[fragment_drop].index, inplace=True)
+            
             fragments_df_dict[sample_id] = fragments_df
 
     # Set groups

--- a/pycisTopic/pseudobulk_peak_calling.py
+++ b/pycisTopic/pseudobulk_peak_calling.py
@@ -290,6 +290,7 @@ def export_pseudobulk_one_sample(
 
     group_pr = pr.PyRanges(group_fragments)
     if isinstance(bigwig_path, str):
+        log.info("Creating bigwig file for " + str(group))
         bigwig_path_group = os.path.join(bigwig_path, str(group) + ".bw")
         if remove_duplicates:
             group_pr.to_bigwig(
@@ -305,6 +306,7 @@ def export_pseudobulk_one_sample(
                 value_col="Score",
             )
     if isinstance(bed_path, str):
+        log.info("Creating bed file for " + str(group))
         bed_path_group = os.path.join(bed_path, str(group) + ".bed.gz")
         group_pr.to_bed(
             path=bed_path_group, keep=False, compression="infer", chain=False

--- a/pycisTopic/pseudobulk_peak_calling.py
+++ b/pycisTopic/pseudobulk_peak_calling.py
@@ -281,7 +281,7 @@ def export_pseudobulk_one_sample(
             group_fragments_dict[list(group_fragments_dict.keys())[x]]
             for x in range(len(fragments_df_dict))
         ]
-        group_fragments = group_fragments_list[0].append(group_fragments_list[1:])
+        group_fragments = pd.concat(group_fragments_list)
 
     del group_fragments_dict
     del group_fragments_list


### PR DESCRIPTION
This PR provides a fix to the issue stated in https://github.com/aertslab/scenicplus/issues/61. 
How it's done: Scaffold chromosomes are filtered out in the `export_pseudobulk` function when the fragments are loaded as DataFrame using a regular expression and the pandas `pd.Series.str.contains()` function. I introduced a new parameter for the `export_pseudobulk` function called `chrom_filter = None`. 

Example following the SCENIC+ tutorial for 10X multiome data: 
```
from pycisTopic.pseudobulk_peak_calling import export_pseudobulk
bw_paths, bed_paths = export_pseudobulk(input_data = cell_data,
                 variable = 'celltype',                                                                     # variable by which to generate pseubulk profiles, in this case we want pseudobulks per celltype
                 sample_id_col = 'sample_id',
                 chromsizes = chromsizes,
                 bed_path = os.path.join(work_dir, 'scATAC/consensus_peak_calling/pseudobulk_bed_files/'),  # specify where pseudobulk_bed_files should be stored
                 bigwig_path = os.path.join(work_dir, 'scATAC/consensus_peak_calling/pseudobulk_bw_files/'),# specify where pseudobulk_bw_files should be stored
                 path_to_fragments = fragments_dict,                                                        # location of fragment files
                 chrom_filter = "GL|KI",
                 n_cpu = 8,                                                                                 # specify the number of cores to use, we use ray for multi processing
                 normalize_bigwig = True,
                 remove_duplicates = True,
                 _temp_dir = tmp_dir,
                 split_pattern = '-')
``` 
Output:
```
2023-08-22 11:16:41,366 cisTopic     INFO     Reading fragments from ../atac_fragments.tsv.gz
2023-08-22 11:19:37,550 cisTopic     INFO     Filtering out 33056 fragments.
2023-08-22 11:20:42,732	INFO worker.py:1627 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265/ 
(export_pseudobulk_ray pid=3011257) 2023-08-22 11:20:46,836 cisTopic     INFO     Creating pseudobulk for CT1
(export_pseudobulk_ray pid=3011259) 2023-08-22 11:20:46,829 cisTopic     INFO     Creating pseudobulk for CT2
(export_pseudobulk_ray pid=3011259) 2023-08-22 11:20:47,958 cisTopic     INFO     Creating pseudobulk for CT3
(export_pseudobulk_ray pid=3011259) 2023-08-22 11:20:50,278 cisTopic     INFO     CT3 done!
```

Thank you for considering. 
